### PR TITLE
Simplified Docker tests setup.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,9 +82,6 @@ celerybeat-schedule
 # SageMath parsed files
 *.sage.py
 
-# dotenv
-.env
-
 # virtualenv
 .venv
 venv/

--- a/tests/.env
+++ b/tests/.env
@@ -1,0 +1,6 @@
+# DON'T quote strings - the following line has is wrong:
+# NEXTCLOUD_HOSTNAME="app"
+
+NEXTCLOUD_ADMIN_USER=admin
+NEXTCLOUD_ADMIN_PASSWORD=admin
+NEXTCLOUD_HOSTNAME=app

--- a/tests/base.py
+++ b/tests/base.py
@@ -5,9 +5,9 @@ from unittest import TestCase
 
 from NextCloud import NextCloud
 
-NEXTCLOUD_URL = "http://{}:80".format(os.environ['NEXTCLOUD_HOST'])
-NEXTCLOUD_USERNAME = os.environ.get('NEXTCLOUD_USERNAME')
-NEXTCLOUD_PASSWORD = os.environ.get('NEXTCLOUD_PASSWORD')
+NEXTCLOUD_URL = "http://{}:80".format(os.environ['NEXTCLOUD_HOSTNAME'])
+NEXTCLOUD_USERNAME = os.environ.get('NEXTCLOUD_ADMIN_USER')
+NEXTCLOUD_PASSWORD = os.environ.get('NEXTCLOUD_ADMIN_PASSWORD')
 
 
 class BaseTestCase(TestCase):

--- a/tests/docker-compose.yml
+++ b/tests/docker-compose.yml
@@ -1,58 +1,28 @@
 version: '3'
 
 services:
-  db:
-    image: postgres:9.6-alpine
-    restart: always
-    networks:
-      - backend
-    volumes:
-      - db:/var/lib/postgresql/data
-    environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: secret
-
   app:
     image: nextcloud:apache
-    restart: always
     networks:
       backend:
-        aliases:
-          - app
-    ports:
-      - 8080:80
-    volumes:
-      - nextcloud:/var/www/html
     environment:
-      POSTGRES_DB: 'nextcloud'
-      POSTGRES_USER: 'postgres'
-      POSTGRES_PASSWORD: 'secret'
-      POSTGRES_HOST: 'db'
-
-      NEXTCLOUD_TRUSTED_DOMAINS: "app"
-      NEXTCLOUD_ADMIN_USER: "admin"
-      NEXTCLOUD_ADMIN_PASSWORD: "admin"
-    depends_on:
-      - db
+      - SQLITE_DATABASE=nextcloud
+      - NEXTCLOUD_TRUSTED_DOMAINS=${NEXTCLOUD_HOSTNAME}
+      - NEXTCLOUD_ADMIN_USER
+      - NEXTCLOUD_ADMIN_PASSWORD
 
   python-api:
     build:
       context: ../
       dockerfile: Dockerfile
     environment:
-      NEXTCLOUD_HOST: "app"
-      NEXTCLOUD_USERNAME: "admin"
-      NEXTCLOUD_PASSWORD: "admin"
+      - NEXTCLOUD_HOSTNAME
+      - NEXTCLOUD_ADMIN_USER
+      - NEXTCLOUD_ADMIN_PASSWORD
     networks:
       backend:
-        aliases:
-          - python-api
     volumes:
       - ../:/usr/src/app
-
-volumes:
-  db:
-  nextcloud:
 
 networks:
     backend:


### PR DESCRIPTION
- Removed the DB container, as Nextcloud is OK with sqlite.
- Introduced the `.env` file, so we don't repeat ourselves in
  `docker-compose.yml`.
- Modified the test setup to reflect those few renames.

