### PR TITLE
Add support for syncing file's last-modified time on upload & donwload

### DIFF
--- a/src/nextcloud/api_wrappers/webdav.py
+++ b/src/nextcloud/api_wrappers/webdav.py
@@ -119,7 +119,7 @@ class WebDAV(WithRequester):
             uid (str): uid of user
             local_filepath (str): path to file on local storage
             remote_filepath (str): path where to upload file on Nextcloud storage
-            timestamp (int):  mtime of upload file. If None, get time by file.
+            timestamp (int):  mtime of upload file. If None, get time by local file.
         """
         with open(local_filepath, 'rb') as f:
             file_contents = f.read()

--- a/src/nextcloud/requester.py
+++ b/src/nextcloud/requester.py
@@ -54,6 +54,15 @@ class Requester(object):
         return self.rtn(res)
 
     @catch_connection_error
+    def put_with_timestamp(self, url="", data=None, timestamp=None):
+        h_post = self.h_post
+        if isinstance(timestamp, (float, int)):
+            h_post["X-OC-MTIME"] = f"{timestamp:.0f}"
+        url = self.get_full_url(url)
+        res = requests.put(url, auth=self.auth_pk, data=data, headers=h_post)
+        return self.rtn(res)
+
+    @catch_connection_error
     def put(self, url="", data=None):
         url = self.get_full_url(url)
         res = requests.put(url, auth=self.auth_pk, data=data, headers=self.h_post)


### PR DESCRIPTION
Hi, this project is wonderful and useful!

The WebDAV API does not support modifying the mtime of a file. However, Nextcloud API allows changing mtime by HTTP X-OC-MTIME header. 

This keeps the modified timestamp (mtime) of files on upload and download.
This script provides the supports to preserve the timestamp of a local file to the upload file on Nextcloud storage with PUT method and X-OC-MTIME header, and set mtime of the local file by meta info on Nextcloud after download.