### PR TITLE
add more options to create user

### DIFF
--- a/src/nextcloud/api_wrappers/user.py
+++ b/src/nextcloud/api_wrappers/user.py
@@ -6,15 +6,30 @@ class User(WithRequester):
     API_URL = "/ocs/v1.php/cloud/users"
     SUCCESS_CODE = 100
 
-    def add_user(self, uid, passwd):
+    def add_user(self, uid, passwd=None, displayName=None, email=None, groups=None, subadmin=None, quota=None, language=None):
         """
         Create a new user on the Nextcloud server
 
-        :param uid: str, uid of new user
-        :param passwd: str, password of new user
+        :param uid: string, the required username for the new user
+        :param passwd: string, the password for the new user, leave empty to send welcome mail
+        :param displayName: string, the display name for the new user
+        :param email: string, the email for the new user, required if password empty
+        :param groups: array, the groups for the new user
+        :param subadmin: array, the groups in which the new user is subadmin
+        :param quota: string, quota for the new user
+        :param language: string, language for the new user
         :return:
         """
-        msg = {'userid': uid, 'password': passwd}
+        msg = {
+            'userid': uid,
+            'password': passwd,
+            'displayName': displayName,
+            'email': email,
+            'groups': groups,
+            'subadmin': subadmin,
+            'quota': quota,
+            'language': language
+        }
         return self.requester.post("", msg)
 
     def get_users(self, search=None, limit=None, offset=None):

--- a/src/nextcloud/requester.py
+++ b/src/nextcloud/requester.py
@@ -28,7 +28,8 @@ class Requester(object):
 
         self.base_url = endpoint
 
-        self.h_get = {"OCS-APIRequest": "true"}
+        self.h_get = {"OCS-APIRequest": "true",
+                      "Accept": "application/json"}
         self.h_post = {"OCS-APIRequest": "true",
                        "Content-Type": "application/json"}
         self.auth_pk = (user, passwd)

--- a/src/nextcloud/requester.py
+++ b/src/nextcloud/requester.py
@@ -30,7 +30,7 @@ class Requester(object):
 
         self.h_get = {"OCS-APIRequest": "true"}
         self.h_post = {"OCS-APIRequest": "true",
-                       "Content-Type": "application/x-www-form-urlencoded"}
+                       "Content-Type": "application/json"}
         self.auth_pk = (user, passwd)
         self.API_URL = None
         self.SUCCESS_CODE = None
@@ -50,7 +50,7 @@ class Requester(object):
     @catch_connection_error
     def post(self, url="", data=None):
         url = self.get_full_url(url)
-        res = requests.post(url, auth=self.auth_pk, data=data, headers=self.h_post)
+        res = requests.post(url, auth=self.auth_pk, json=data, headers=self.h_post)
         return self.rtn(res)
 
     @catch_connection_error


### PR DESCRIPTION
Add all options for user creation as in https://docs.nextcloud.com/server/14/admin_manual/configuration_user/instruction_set_for_users.html#add-a-new-user

This is required to be able to send welcome mails without setting a password.

It was necessary to switch post requests to send json, as python requests apparently cannot handle arrays with content-type `x-www-form-urlencoded`