### PR TITLE
fix path sep on Windows 

### DIFF
--- a/src/nextcloud/api_wrappers/webdav.py
+++ b/src/nextcloud/api_wrappers/webdav.py
@@ -172,7 +172,7 @@ class WebDAV(WithRequester):
             folder_path (str): The folder tree
         Returns:
         """
-        tree = pathlib.PurePath(tree_path)
+        tree = pathlib.PurePosixPath(tree_path)
         parents = list(tree.parents)
         ret = True
         subfolders = parents[:-1][::-1] + [tree]


### PR DESCRIPTION
If the module is used on Windows, PurePath converts to backslashes, which seems to fail with the Nextcloud paths.
I saw this behaviour with `assure_tree_exists`.