### PR TITLE
Fix and modification of "download_file"

### DIFF
--- a/src/nextcloud/api_wrappers/webdav.py
+++ b/src/nextcloud/api_wrappers/webdav.py
@@ -2,6 +2,7 @@
 import re
 import os
 import pathlib
+from urllib.parse import unquote
 
 import xml.etree.ElementTree as ET
 
@@ -92,6 +93,7 @@ class WebDAV(WithRequester):
         """
         additional_url = "/".join([uid, path])
         filename = path.split('/')[-1] if '/' in path else path
+        filename = unquote(filename)
         file_data = self.list_folders(uid=uid, path=path, depth=0)
 
         if not file_data:


### PR DESCRIPTION
There was an error when downloading text files on `f.write(res.data)` in webdav.py:
```
TypeError: a bytes-like object is required, not 'str'
```

I also added a two new parameters to this function:
- download_path (str): to specify where you want to download the file instead of assuming "./"
- overwrite (bool): to choose if you want to overwrite files or you want to raise an exception on duplicate files.